### PR TITLE
Create functionality for removing an idea

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -4,12 +4,20 @@ import IdeaBoxContainer from '../IdeaBoxContainer/IdeaBoxContainer';
 
 
 const App: React.FC = () => {
-  const [ideas, setIdeas] = useState<Array<any>>([]);
+  const [ideas, setIdeas] = useState<any>([]);
+
+  const removeIdea = (ideaToRemove:any) => {
+    if (ideas.length === 1) {
+      setIdeas([]);
+    } else {
+      setIdeas(ideas.filter((idea:any) => idea !== ideaToRemove));
+    }
+  }
 
   return (
     <div className="App">
       < NewIdeaForm addIdea={setIdeas} ideas={ideas} />
-      < IdeaBoxContainer ideas={ideas}/>
+      < IdeaBoxContainer ideas={ideas} deleteIdea={removeIdea}/>
     </div>
   );
 }

--- a/src/components/IdeaBox/IdeaBox.tsx
+++ b/src/components/IdeaBox/IdeaBox.tsx
@@ -4,14 +4,21 @@ type Props = {
   idea: {
     title: string;
     description: string;
-  }
+  };
+  deleteIdea: any;
 };
 
-const IdeaBox = ({idea}: Props) => {
+const IdeaBox = ({idea, deleteIdea}: Props) => {
+
+  const deleteIdeaBox = () => {
+    deleteIdea(idea);
+  }
+
   return (
     <article className='idea-box'>
       <h2 className='idea-box-title'>{idea.title}</h2>
       <p className='idea-box-description'>{idea.description}</p>
+      <button className='delete-btn' onClick={deleteIdeaBox}>Delete Idea</button>
     </article>
   )
 }

--- a/src/components/IdeaBoxContainer/IdeaBoxContainer.tsx
+++ b/src/components/IdeaBoxContainer/IdeaBoxContainer.tsx
@@ -5,7 +5,8 @@ type Props = {
   ideas: {
     title: string;
     description: string;
-  }[]
+  }[];
+  deleteIdea: any;
 };
 
 type Idea = {
@@ -13,12 +14,16 @@ type Idea = {
   description: string;
 };
 
-const IdeaBoxContainer = ({ideas}: Props) => {
+const IdeaBoxContainer = ({ideas, deleteIdea}: Props) => {
 
   const createIdeaBoxes = () =>
     ideas.map((idea:Idea) => {
       return (
-        < IdeaBox idea={idea} key={ideas.length}/>
+        < IdeaBox
+          idea={idea}
+          key={ideas.indexOf(idea)}
+          deleteIdea={deleteIdea}
+        />
       )
     })
 


### PR DESCRIPTION
This PR includes the functionality for removing an idea by clicking a 'Delete' button on an idea. This method of removing an idea lives in the `App` component and is passed down as a prop to the `IdeaBoxContainer` component, which it's then passed down to to our `IdeaBox` component so that each idea that is created will have this delete option.

#### What I Learned
- I learned that trying to utilize `.splice()` on a piece of state thats an array throws some wonky functionality. I was not receiving any erros in the console, but everytime I had more than 2 ideas and tried to delete one, it would remove all but one. So after further research, I went forward with a `.filter()` method where I am filtering out all the ideas that are not strictly equal to the idea that I am deleting.